### PR TITLE
Delete the npm install command to use it one time

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,11 @@ The project uses [repo deploy keys](https://developer.github.com/v3/guides/manag
 
 The project can update the version of the documentation using the `package.json` semantic version as its reference. This will only work with minor or patch updates for the first documentation versioning or in case of a major update you will need to perform this update manually. [Here](https://docusaurus.io/docs/en/versioning) you can check the steps to do the manual version update.
 
+## Filter and install
+We need to install the `Docusaurus` dependencies to process with the action; we use the [npm install action](https://github.com/actions/npm) to this purpose.  
+
+Also, we only activate the action when there is an update on the `master branch`. We use the [filter action](https://github.com/actions/bin/tree/master/filter) to check if the event that we target perform an update on master.
+
 ---
 
 We use the `args` attribute to know which action we need to run as you can see on the `main.workflow` example.
@@ -29,14 +34,16 @@ action "Filter Master" {
   args = "branch master"
 }
 
+action "Install" {
+  needs = ["Filter branch"]
+  uses = "actions/npm@master"
+  args = "install --prefix ./website"
+}
+
 action "Update version" {
-  needs = ["Filter Master"]
+  needs = ["Install"]
   uses = "clay/docusaurus-github-action@master"
   args = "version"
-  env={
-      BUILD_DIR = "website",
-      PROJECT_NAME = "clay"
-  }
 }
 
 action "Deploy Docs" {

--- a/bin/deploy
+++ b/bin/deploy
@@ -24,7 +24,6 @@ cd $BUILD_DIR;
 
 git config --global user.name "$GITHUB_ACTOR" && \
 git config --global user.email "$GITHUB_ACTOR@users.noreply.github.com" && \
-npm install && \
 npm run build && \
 npx gh-pages -d "build/$PROJECT_NAME" --repo "git@github.com:$GITHUB_REPOSITORY.git"
 # We need for force an SSH connection to use the SSH key so

--- a/bin/version
+++ b/bin/version
@@ -17,7 +17,6 @@ if ! [ -z "$MAJOR_DOCS_VERSION" ] && [ $MAJOR_PACKAGE_VERSION == $MAJOR_DOCS_VER
   cd ..
   PACKAGE_VERSION="$(sed -nE 's/.*version.*"(([0-9]+)\.([0-9]+\.?)+)".*/\1/p' package.json)"
   cd $BUILD_DIR
-  npm install && \
   npm run version $PACKAGE_VERSION
 else
   echo "In case of a major release or first docs update; you need to do the version update manually"


### PR DESCRIPTION
Eliminate `npm install` command to use the github's [npm action](https://github.com/actions/npm) and install just one time all modules